### PR TITLE
Showcase the error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - checkout
       - run: yarn
-      - run: node -e "console.log('hello world')"
+      - run: node -p "require('bcrypt').hashSync('password', 5)"

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "name": "local-circle-test",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "bcrypt": "^3.0.1"
+  }
 }


### PR DESCRIPTION
_note: see the bug report here: https://github.com/CircleCI-Public/circleci-cli/issues/151_

This version of the code will run fine on circleci.com.

But when run locally on a non-Linux machine (eg; OSX), it will produce errors:

```bash
# creates the `node_modules` directory which is incorrectly copied to the docker image
yarn

# run the local circleci command
circleci local execute --job build
```

<details>
 <summary>Gives the following output</summary>

```
❯ circleci local execute --job build
Docker image digest: sha256:3d88cfffd448da07ff8ced22ccdca5adc09ff18e87dc7db9b8af5b8a47647c08
====>> Spin up Environment
Build-agent version 0.1.750-336e0196 (2018-09-13T19:48:06+0000)
Starting container circleci/node:carbon-browsers
  using image circleci/node@sha256:e116faa71d34d76287d6b2a81abeeadd5897f508e14b41391b29ed882c820022
Using build environment variables:
  BASH_ENV=/tmp/.bash_env-localbuild-1538887853
  CI=true
  CIRCLECI=true
  CIRCLE_BRANCH=the-error
  CIRCLE_BUILD_NUM=
  CIRCLE_JOB=build
  CIRCLE_NODE_INDEX=0
  CIRCLE_NODE_TOTAL=1
  CIRCLE_REPOSITORY_URL=git@github.com:jesstelford/local-circleci-test.git
  CIRCLE_SHA1=bbde846be5368499be3eb79f3154d4c017ab9122
  CIRCLE_SHELL_ENV=/tmp/.bash_env-localbuild-1538887853
  CIRCLE_WORKING_DIRECTORY=/home/circleci/repo
====>> Checkout code
  #!/bin/bash -eo pipefail
mkdir -p /home/circleci/repo && cp -r /tmp/_circleci_local_build_repo/. /home/circleci/repo
====>> yarn
  #!/bin/bash -eo pipefail
yarn
yarn install v1.9.4
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 2.34s.
====>> node -p "require('bcrypt').hashSync('password', 5)"
  #!/bin/bash -eo pipefail
node -p "require('bcrypt').hashSync('password', 5)"
module.js:682
  return process.dlopen(module, path._makeLong(filename));
                 ^

Error: /home/circleci/repo/node_modules/bcrypt/lib/binding/bcrypt_lib.node: invalid ELF header
    at Object.Module._extensions..node (module.js:682:18)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/circleci/repo/node_modules/bcrypt/bcrypt.js:6:16)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
Error: Exited with code 1
Step failed
Error: runner failed
Task failed
```
</details>

---

However, if you remove `node_modules`, everything runs fine:

```bash
# clean up files that aren't meant to be copied to the docker image
rm -rf node_modules

# run the local circleci command
circleci local execute --job build
```

<details>
 <summary>Gives the following output</summary>

```
❯ circleci local execute --job build
Docker image digest: sha256:3d88cfffd448da07ff8ced22ccdca5adc09ff18e87dc7db9b8af5b8a47647c08
====>> Spin up Environment
Build-agent version 0.1.750-336e0196 (2018-09-13T19:48:06+0000)
Starting container circleci/node:carbon-browsers
  using image circleci/node@sha256:e116faa71d34d76287d6b2a81abeeadd5897f508e14b41391b29ed882c820022
Using build environment variables:
  BASH_ENV=/tmp/.bash_env-localbuild-1538887959
  CI=true
  CIRCLECI=true
  CIRCLE_BRANCH=the-error
  CIRCLE_BUILD_NUM=
  CIRCLE_JOB=build
  CIRCLE_NODE_INDEX=0
  CIRCLE_NODE_TOTAL=1
  CIRCLE_REPOSITORY_URL=git@github.com:jesstelford/local-circleci-test.git
  CIRCLE_SHA1=bbde846be5368499be3eb79f3154d4c017ab9122
  CIRCLE_SHELL_ENV=/tmp/.bash_env-localbuild-1538887959
  CIRCLE_WORKING_DIRECTORY=/home/circleci/repo
====>> Checkout code
  #!/bin/bash -eo pipefail
mkdir -p /home/circleci/repo && cp -r /tmp/_circleci_local_build_repo/. /home/circleci/repo
====>> yarn
  #!/bin/bash -eo pipefail
yarn
yarn install v1.9.4
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 5.15s.
====>> node -p "require('bcrypt').hashSync('password', 5)"
  #!/bin/bash -eo pipefail
node -p "require('bcrypt').hashSync('password', 5)"
$2b$05$XhiGPRaOV607/aGp9Th08OdyJPKFVQztuqWREyjTk4IYTPX1W5XXu
Success!
```
</details>